### PR TITLE
feat(Picker): import the Picker from community package instead of rea…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,13 @@
     "validate-commit-msg": "^2.11.2"
   },
   "dependencies": {
-    "react-native-root-siblings": "3.2.1",
-    "react-native-root-toast": "3.1.1",
+    "@react-native-picker/picker": "^2.2.1",
     "date-fns": "^1.28.5",
     "lodash": "^4.17.4",
     "node-polyglot": "^2.2.2",
     "react-native-modalbox": "^1.7.1",
+    "react-native-root-siblings": "3.2.1",
+    "react-native-root-toast": "3.1.1",
     "validator": "^6.2.1"
   },
   "peerDependencies": {

--- a/src/Picker.js
+++ b/src/Picker.js
@@ -1,7 +1,8 @@
 // @flow
 
 import React, { PureComponent } from 'react';
-import { Picker, Platform, View } from 'react-native';
+import { Platform, View } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import { DisableInputKeyboard, KeyboardModal, TextInput } from '.';
 
 type _Props = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,11 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
+"@react-native-picker/picker@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.2.1.tgz#32b9f540d8e88a73d8856f73cca88251cecb9614"
+  integrity sha512-EC7yv22QLHlTfnbC1ez9IUdXTOh1W31x96Oir0PfskSGFFJMWWdLTg4VrcE2DsGLzbfjjkBk123c173vf2a5MQ==
+
 "@semantic-release/commit-analyzer@^6.1.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-6.1.0.tgz#32bbe3c23da86e23edf072fbb276fa2f383fcb17"


### PR DESCRIPTION
import the Picker from @react-native-picker/picker package instead of react-native because it is deprecated with the last versions of react-native